### PR TITLE
Fixed a bug in CSV export (#3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "powertable",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "A conversion of @Muonw's Powertable component. Allows filtering, wildcard search, custom formatting and more!",
   "license": "MIT",
   "svelte": "index.js",
@@ -22,7 +22,7 @@
     "@tsconfig/svelte": "^3.0.0",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.2.10",
-    "rollup": "^2.44.0",
+    "rollup": "^2.79.1",
     "rollup-plugin-copy2": "^0.3.1",
     "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-polyfill-node": "^0.8.0",

--- a/src/Component.svelte
+++ b/src/Component.svelte
@@ -75,62 +75,6 @@
     checkboxColumn: rowSelection,
   };
 
-/* function exportCsv() {
-  let json = ptData;
-  var fields = Object.keys(json[0]);
-
-  var idIndex = fields.indexOf('_id');
-  if (idIndex > -1) {
-    fields.splice(idIndex, 1);
-  }
-
-  var replacer = function (key, value) {
-    if (typeof value === "string") {
-      // Replace commas with semicolons in string values
-      value = value.replace(/,/g, ';');
-    }
-    return value === null ? "" : value;
-  };
-
-  var csv = json.map(function (row) {
-    return fields
-      .map(function (fieldName) {
-        return JSON.stringify(row[fieldName], replacer);
-      })
-      .join(",");
-  });
-  
-  // Log the csv array before joining with newlines
-  let csvArrayLogContent = "data:text/plain;charset=utf-8," + encodeURIComponent(JSON.stringify(csv, null, 2));
-  var downloadLink = document.createElement("a");
-  downloadLink.href = csvArrayLogContent;
-  downloadLink.download = "csvArrayLog.txt";
-  document.body.appendChild(downloadLink);
-  downloadLink.click();
-  document.body.removeChild(downloadLink);
-
-  csv.unshift(fields.join(","));
-  csv = csv.join("\n");
-
-  // Log the final csv string
-  let csvStringLogContent = "data:text/plain;charset=utf-8," + encodeURIComponent(csv);
-  downloadLink = document.createElement("a");
-  downloadLink.href = csvStringLogContent;
-  downloadLink.download = "csvStringLog.txt";
-  document.body.appendChild(downloadLink);
-  downloadLink.click();
-  document.body.removeChild(downloadLink);
-
-  let csvContent = "data:text/csv;charset=utf-8," + encodeURIComponent(csv);
-  downloadLink = document.createElement("a");
-  downloadLink.href = csvContent;
-  downloadLink.download = "data.csv";
-  document.body.appendChild(downloadLink);
-  downloadLink.click();
-  document.body.removeChild(downloadLink);
-}
- */
-
 function exportCsv() {
   let json = ptData;
   var fields = Object.keys(json[0]);

--- a/src/Component.svelte
+++ b/src/Component.svelte
@@ -75,36 +75,36 @@
     checkboxColumn: rowSelection,
   };
 
-function exportCsv() {
-  let json = ptData;
-  var fields = Object.keys(json[0]);
+  function exportCsv() {
+    let json = ptData;
+    var fields = Object.keys(json[0]);
 
-  var idIndex = fields.indexOf('_id');
-  if (idIndex > -1) {
-    fields.splice(idIndex, 1);
+    var idIndex = fields.indexOf('_id');
+    if (idIndex > -1) {
+      fields.splice(idIndex, 1);
+    }
+
+    var replacer = function (key, value) {
+      return value === null ? "" : value;
+    };
+    var csv = json.map(function (row) {
+      return fields
+        .map(function (fieldName) {
+          return JSON.stringify(row[fieldName], replacer);
+        })
+        .join(",");
+    });
+    csv.unshift(fields.join(",")); // add header column
+    csv = csv.join("\n");
+    let csvContent = "data:text/csv;charset=utf-8," + encodeURIComponent(csv);
+    var downloadLink = document.createElement("a");
+    downloadLink.href = csvContent;
+    downloadLink.download = "data.csv";
+
+    document.body.appendChild(downloadLink);
+    downloadLink.click();
+    document.body.removeChild(downloadLink);
   }
-
-  var replacer = function (key, value) {
-    return value === null ? "" : value;
-  };
-  var csv = json.map(function (row) {
-    return fields
-      .map(function (fieldName) {
-        return JSON.stringify(row[fieldName], replacer);
-      })
-      .join(",");
-  });
-  csv.unshift(fields.join(",")); // add header column
-  csv = csv.join("\n");
-  let csvContent = "data:text/csv;charset=utf-8," + encodeURIComponent(csv);
-  var downloadLink = document.createElement("a");
-  downloadLink.href = csvContent;
-  downloadLink.download = "data.csv";
-
-  document.body.appendChild(downloadLink);
-  downloadLink.click();
-  document.body.removeChild(downloadLink);
-}
 
 </script>
 

--- a/src/Component.svelte
+++ b/src/Component.svelte
@@ -89,7 +89,7 @@
         .join(",");
     });
     csv.unshift(fields.join(",")); // add header column
-    csv = csv.join("\r\n");
+    csv = csv.join("\n");
     let csvContent = "data:text/csv;charset=utf-8," + csv;
     var downloadLink = document.createElement("a");
     downloadLink.href = csvContent;

--- a/src/Component.svelte
+++ b/src/Component.svelte
@@ -75,30 +75,93 @@
     checkboxColumn: rowSelection,
   };
 
-  function exportCsv() {
-    let json = ptData;
-    var fields = Object.keys(json[0]);
-    var replacer = function (key, value) {
-      return value === null ? "" : value;
-    };
-    var csv = json.map(function (row) {
-      return fields
-        .map(function (fieldName) {
-          return JSON.stringify(row[fieldName], replacer);
-        })
-        .join(",");
-    });
-    csv.unshift(fields.join(",")); // add header column
-    csv = csv.join("\n");
-    let csvContent = "data:text/csv;charset=utf-8," + csv;
-    var downloadLink = document.createElement("a");
-    downloadLink.href = csvContent;
-    downloadLink.download = "data.csv";
+/* function exportCsv() {
+  let json = ptData;
+  var fields = Object.keys(json[0]);
 
-    document.body.appendChild(downloadLink);
-    downloadLink.click();
-    document.body.removeChild(downloadLink);
+  var idIndex = fields.indexOf('_id');
+  if (idIndex > -1) {
+    fields.splice(idIndex, 1);
   }
+
+  var replacer = function (key, value) {
+    if (typeof value === "string") {
+      // Replace commas with semicolons in string values
+      value = value.replace(/,/g, ';');
+    }
+    return value === null ? "" : value;
+  };
+
+  var csv = json.map(function (row) {
+    return fields
+      .map(function (fieldName) {
+        return JSON.stringify(row[fieldName], replacer);
+      })
+      .join(",");
+  });
+  
+  // Log the csv array before joining with newlines
+  let csvArrayLogContent = "data:text/plain;charset=utf-8," + encodeURIComponent(JSON.stringify(csv, null, 2));
+  var downloadLink = document.createElement("a");
+  downloadLink.href = csvArrayLogContent;
+  downloadLink.download = "csvArrayLog.txt";
+  document.body.appendChild(downloadLink);
+  downloadLink.click();
+  document.body.removeChild(downloadLink);
+
+  csv.unshift(fields.join(","));
+  csv = csv.join("\n");
+
+  // Log the final csv string
+  let csvStringLogContent = "data:text/plain;charset=utf-8," + encodeURIComponent(csv);
+  downloadLink = document.createElement("a");
+  downloadLink.href = csvStringLogContent;
+  downloadLink.download = "csvStringLog.txt";
+  document.body.appendChild(downloadLink);
+  downloadLink.click();
+  document.body.removeChild(downloadLink);
+
+  let csvContent = "data:text/csv;charset=utf-8," + encodeURIComponent(csv);
+  downloadLink = document.createElement("a");
+  downloadLink.href = csvContent;
+  downloadLink.download = "data.csv";
+  document.body.appendChild(downloadLink);
+  downloadLink.click();
+  document.body.removeChild(downloadLink);
+}
+ */
+
+function exportCsv() {
+  let json = ptData;
+  var fields = Object.keys(json[0]);
+
+  var idIndex = fields.indexOf('_id');
+  if (idIndex > -1) {
+    fields.splice(idIndex, 1);
+  }
+
+  var replacer = function (key, value) {
+    return value === null ? "" : value;
+  };
+  var csv = json.map(function (row) {
+    return fields
+      .map(function (fieldName) {
+        return JSON.stringify(row[fieldName], replacer);
+      })
+      .join(",");
+  });
+  csv.unshift(fields.join(",")); // add header column
+  csv = csv.join("\n");
+  let csvContent = "data:text/csv;charset=utf-8," + encodeURIComponent(csv);
+  var downloadLink = document.createElement("a");
+  downloadLink.href = csvContent;
+  downloadLink.download = "data.csv";
+
+  document.body.appendChild(downloadLink);
+  downloadLink.click();
+  document.body.removeChild(downloadLink);
+}
+
 </script>
 
 <div use:styleable={$component.styles}>


### PR DESCRIPTION
Fixed a bug in CSV export. This solves issue #3. Previously, the export would accidentaly leave out newlines, resulting in all csv content being in one long string. Also removed the output of the internal _id row identifier field from the content being exported. Also changed from the Windows newline character \r\n to \n. 